### PR TITLE
AdminUser 레포,API,컨트롤러,서비스,매퍼 작성

### DIFF
--- a/goodgame.gg/src/main/java/fourjo/idle/goodgame/gg/repository/AdminRepository.java
+++ b/goodgame.gg/src/main/java/fourjo/idle/goodgame/gg/repository/AdminRepository.java
@@ -1,5 +1,6 @@
 package fourjo.idle.goodgame.gg.repository;
 
+import fourjo.idle.goodgame.gg.web.dto.AdminUserSelectAll;
 import fourjo.idle.goodgame.gg.web.dto.UserDto;
 import org.apache.ibatis.annotations.Mapper;
 
@@ -9,8 +10,13 @@ import java.util.List;
 public interface AdminRepository {
 
 
-    public int userUpdate(UserDto userDto);
-    public int userDelete(UserDto userDto);
+    public int AdminUserUpdate(UserDto dto);
+    public int AdminUserDelete(int user_index);
 
+    public List<UserDto> AdminUserSelectAll();
+
+    public List<UserDto> AdminUserSearchList(String user_nick);
+
+    public UserDto AdminUserSelectOne(int user_index);
 
 }

--- a/goodgame.gg/src/main/java/fourjo/idle/goodgame/gg/web/api/AdminApi.java
+++ b/goodgame.gg/src/main/java/fourjo/idle/goodgame/gg/web/api/AdminApi.java
@@ -1,5 +1,6 @@
 package fourjo.idle.goodgame.gg.web.api;
 
+import fourjo.idle.goodgame.gg.web.dto.AdminUserSelectAll;
 import fourjo.idle.goodgame.gg.web.dto.CMRespDto;
 import fourjo.idle.goodgame.gg.web.dto.UserDto;
 import fourjo.idle.goodgame.gg.web.service.AdminService;
@@ -10,32 +11,49 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/admin")
-@Tag(name ="Admin Api", description = "Admin Api 입니다.")
+@RequestMapping("/api/admin_user")
+@Tag(name ="Admin User Api", description = "Admin User Api 입니다.")
 public class AdminApi {
 
     @Autowired
     private AdminService adminService;
 
-    @PostMapping("/userUpdate")
-    public ResponseEntity<CMRespDto<?>> userUpdate (@RequestBody UserDto userDto, BindingResult bindingResult){
-        adminService.userUpdate(userDto);
+    @PostMapping("/AdminUserUpdate")
+    public ResponseEntity<CMRespDto<?>> AdminUserUpdate (@RequestBody UserDto userDto, BindingResult bindingResult){
+        adminService.AdminUserUpdate(userDto);
         return ResponseEntity.ok()
                 .body(new CMRespDto<>(HttpStatus.OK.value(), "Successfully registered", true));
     }
-    @PostMapping("/userDelete")
-    public ResponseEntity<CMRespDto<?>> userDelete (@RequestBody UserDto userDto, BindingResult bindingResult){
-        adminService.userDelete(userDto);
+    @PostMapping("/AdminUserDelete")
+    public ResponseEntity<CMRespDto<?>> AdminUserDelete (int user_index){
+        adminService.AdminUserDelete(user_index);
         return ResponseEntity.ok()
                 .body(new CMRespDto<>(HttpStatus.OK.value(), "Successfully registered", true));
     }
+    @GetMapping("/all/AdminUserSelectAll")
+    public ResponseEntity<CMRespDto<?>> AdminUserSelectAll( ) {
 
+        return ResponseEntity
+                .ok()
+                .body(new CMRespDto<>(HttpStatus.OK.value(), "Successfully",adminService.AdminUserSelectAll()));
+    }
+    @GetMapping("/all/AdminUserSearchList")
+    public ResponseEntity<CMRespDto<?>> AdminUserSearchList(String user_nick) {
+
+        return ResponseEntity
+                .ok()
+                .body(new CMRespDto<>(HttpStatus.OK.value(), "Successfully",    adminService.AdminUserSearchList(user_nick)));
+    }
+    @GetMapping("/all/AdminUserSelectOne")
+    public ResponseEntity<CMRespDto<?>> AdminUserSelectOne(int user_index) {
+
+        return ResponseEntity
+                .ok()
+                .body(new CMRespDto<>(HttpStatus.OK.value(), "Successfully",    adminService.AdminUserSelectOne(user_index)));
+    }
 }

--- a/goodgame.gg/src/main/java/fourjo/idle/goodgame/gg/web/controller/AdminController.java
+++ b/goodgame.gg/src/main/java/fourjo/idle/goodgame/gg/web/controller/AdminController.java
@@ -1,18 +1,36 @@
 package fourjo.idle.goodgame.gg.web.controller;
 
+import fourjo.idle.goodgame.gg.web.dto.UserDto;
+import fourjo.idle.goodgame.gg.web.service.AdminService;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 
+import java.util.List;
+
 @Controller
 public class AdminController {
-
-    @GetMapping("/userUpdate")
-    public String userUpdate(){
-        return "admin/userUpdate";
+@Autowired
+AdminService adminService;
+    @GetMapping("/AdminUserUpdate")
+    public String AdminUserUpdate(){
+        return "admin/AdminUserUpdate";
     }
-    @GetMapping("/userDelete")
-    public String userDelete(){
-        return "admin/userDelete";
+    @GetMapping("/AdminUserDelete")
+    public String AdminUserDelete(){
+        return "admin/AdminUserDelete";
+    }
+    @GetMapping("/AdminUserSelectAll")
+    public String AdminUserSelectAll(){
+        return "admin/AdminUserSelectAll";
     }
 
+    @GetMapping("/AdminUserSearchList")
+    public String AdminUserSearchList(){
+        return "admin/AdminUserSearchList";
+    }
+    @GetMapping("/AdminUserSelectOne")
+    public String AdminUserSelectOne(){
+        return "admin/AdminUserSelectOne";
+    }
 }

--- a/goodgame.gg/src/main/java/fourjo/idle/goodgame/gg/web/service/AdminService.java
+++ b/goodgame.gg/src/main/java/fourjo/idle/goodgame/gg/web/service/AdminService.java
@@ -1,25 +1,40 @@
 package fourjo.idle.goodgame.gg.web.service;
 
 import fourjo.idle.goodgame.gg.repository.AdminRepository;
+import fourjo.idle.goodgame.gg.web.dto.AdminUserSelectAll;
 import fourjo.idle.goodgame.gg.web.dto.UserDto;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
 
 @Service
+@Slf4j
 public class AdminService {
 
     @Autowired
     private AdminRepository adminRepository;
 
 
-    public int userUpdate(UserDto dto) {
-        return adminRepository.userUpdate(dto);
+    public int AdminUserUpdate(UserDto dto) {
+        return adminRepository.AdminUserUpdate(dto);
     }
 
-    public int userDelete(UserDto dto) {
-        return adminRepository.userDelete(dto);
-    }
+    public int AdminUserDelete(int user_index) {
 
+        return adminRepository.AdminUserDelete(user_index);
+    }
+    public List<UserDto> AdminUserSelectAll(  ) {
+
+        return adminRepository.AdminUserSelectAll();
+    }
+    public List<UserDto> AdminUserSearchList(String user_nick  ) {
+
+        return adminRepository.AdminUserSearchList(user_nick);
+    }
+    public UserDto AdminUserSelectOne(int user_index  ) {
+
+        return adminRepository.AdminUserSelectOne(user_index);
+    }
 }

--- a/goodgame.gg/src/main/resources/mappers/admin.xml
+++ b/goodgame.gg/src/main/resources/mappers/admin.xml
@@ -6,15 +6,58 @@
 
 
 
-    <update id="userUpdate" parameterType="fourjo.idle.goodgame.gg.web.dto.UserDto">
+    <update id="AdminUserUpdate" parameterType="fourjo.idle.goodgame.gg.web.dto.UserDto">
         update user_mst set user_nick=#{userNick}
         where user_index=#{userIndex}
     </update>
 
-    <delete id="userDelete" parameterType="fourjo.idle.goodgame.gg.web.dto.UserDto">
-        delete from user_mst where user_index=#{userIndex}
+    <delete id="AdminUserDelete" parameterType="integer" >
+        delete from user_mst where user_index= #{user_index}
     </delete>
 
 
+    <select id="AdminUserSelectAll"  resultType="fourjo.idle.goodgame.gg.web.dto.UserDto">
+      select
+        user_index as userIndex,
+        user_id as userId,
+        user_pw as userPw,
+        user_nick as userNick,
+        user_gender as userGender,
+        user_reg_date as userRegDate,
+        user_email as userEmail,
+        role_id as roleId
+        from user_mst
+        where user_index=#{user_index}
 
+    </select>
+
+    <select id="AdminUserSearchList"  parameterType="string" resultType="fourjo.idle.goodgame.gg.web.dto.UserDto">
+    select
+    user_index as userIndex,
+    user_id as userId,
+    user_pw as userPw,
+    user_nick as userNick,
+    user_gender as userGender,
+    user_reg_date as userRegDate,
+    user_email as userEmail,
+    role_id as roleId
+    from user_mst
+    where user_nick like CONCAT('%', #{user_nick}, '%')
+
+</select>
+
+    <select id="AdminUserSelectOne"  parameterType="integer" resultType="fourjo.idle.goodgame.gg.web.dto.UserDto">
+        select
+        user_index as userIndex,
+        user_id as userId,
+        user_pw as userPw,
+        user_nick as userNick,
+        user_gender as userGender,
+        user_reg_date as userRegDate,
+        user_email as userEmail,
+        role_id as roleId
+        from user_mst
+        where user_index=#{user_index}
+
+    </select>
 </mapper>


### PR DESCRIPTION
AdminUser 기능 구현 추가
AdminUserUpdate:  user_index 사용하여 입력 받은 user_nick으로 업데이트
AdminUserDelete: 입력받은 user_index의 user삭제
AdminUserSelectAll: 페이징 없이 모든 데이터 출력->추후 페이징 추가 예정
AdminUserSearchList: 입력받은 user_nick으로 검색 기능 구현-> 추후 다른 기준(아이디나 성별?) 기능 추가 예정
AdminUserSelectOne: 입력받은 user_index의 user정보 출력
에 필요한 레포지토리,컨트롤러,API,서비스,매퍼 작성
