### PR TITLE
2024-04-05 금 마지막 커밋 내용

### DIFF
--- a/goodgame.gg/pom.xml
+++ b/goodgame.gg/pom.xml
@@ -46,21 +46,6 @@
 			<groupId>org.thymeleaf.extras</groupId>
 			<artifactId>thymeleaf-extras-springsecurity6</artifactId>
 		</dependency>
-
-<!--		<dependency>-->
-<!--			<groupId>org.springdoc</groupId>-->
-<!--			<artifactId>springdoc-openapi</artifactId>-->
-<!--			<version>2.4.0</version>-->
-<!--			<type>pom</type>-->
-<!--		</dependency>-->
-
-<!--		<dependency>-->
-<!--			<groupId>org.springdoc</groupId>-->
-<!--			<artifactId>springdoc-openapi-ui</artifactId>-->
-<!--			<version>1.8.0</version>-->
-<!--		</dependency>-->
-
-
 		<dependency>
 			<groupId>io.springfox</groupId>
 			<artifactId>springfox-swagger2</artifactId>
@@ -112,6 +97,12 @@
 			<groupId>org.springframework.security</groupId>
 			<artifactId>spring-security-test</artifactId>
 			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.httpcomponents</groupId>
+			<artifactId>httpclient</artifactId>
+			<version>4.5</version>
 		</dependency>
 	</dependencies>
 

--- a/goodgame.gg/src/main/java/fourjo/idle/goodgame/gg/exception/CustomRiotResponseCodeException.java
+++ b/goodgame.gg/src/main/java/fourjo/idle/goodgame/gg/exception/CustomRiotResponseCodeException.java
@@ -1,0 +1,12 @@
+package fourjo.idle.goodgame.gg.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.Map;
+
+@AllArgsConstructor
+@Getter
+public class CustomRiotResponseCodeException extends RuntimeException{
+    private Map<String, Integer> errorMap;
+}

--- a/goodgame.gg/src/main/java/fourjo/idle/goodgame/gg/web/advice/ExceptionAdvice.java
+++ b/goodgame.gg/src/main/java/fourjo/idle/goodgame/gg/web/advice/ExceptionAdvice.java
@@ -1,6 +1,7 @@
 package fourjo.idle.goodgame.gg.web.advice;
 
 import fourjo.idle.goodgame.gg.exception.CustomInputUserGenderException;
+import fourjo.idle.goodgame.gg.exception.CustomRiotResponseCodeException;
 import fourjo.idle.goodgame.gg.exception.CustomSameUserIdException;
 import fourjo.idle.goodgame.gg.exception.CustomValidationException;
 import fourjo.idle.goodgame.gg.web.dto.CMRespDto;
@@ -28,5 +29,11 @@ public class ExceptionAdvice {
     public ResponseEntity<?> inputUserGenderError(CustomInputUserGenderException e){
         return ResponseEntity.badRequest()
                 .body(new CMRespDto<>(HttpStatus.BAD_REQUEST.value(), "InputUserGender Error", e.getErrorMap()));
+    }
+
+    @ExceptionHandler(CustomRiotResponseCodeException.class)
+    public ResponseEntity<?> riotResponseCodeException(CustomRiotResponseCodeException e){
+        return ResponseEntity.badRequest()
+                .body(new CMRespDto<>(HttpStatus.BAD_REQUEST.value(), "riot response Error", e.getErrorMap()));
     }
 }

--- a/goodgame.gg/src/main/java/fourjo/idle/goodgame/gg/web/api/RecordApi.java
+++ b/goodgame.gg/src/main/java/fourjo/idle/goodgame/gg/web/api/RecordApi.java
@@ -1,0 +1,47 @@
+package fourjo.idle.goodgame.gg.web.api;
+
+import fourjo.idle.goodgame.gg.web.dto.CMRespDto;
+import fourjo.idle.goodgame.gg.web.dto.Record.LeagueDto;
+import fourjo.idle.goodgame.gg.web.dto.Record.SummonerDto;
+import fourjo.idle.goodgame.gg.web.service.RecordService;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/record")
+@Tag(name = "Record Api", description = "Record Api 입니다.")
+public class RecordApi {
+
+    @Autowired
+    private RecordService recordService;
+
+    @PostMapping(value = "/searchSummonerName")
+    public ResponseEntity<CMRespDto<?>> SearchRecordAll(String summonerName){
+
+        summonerName = summonerName.replaceAll(" ", "%20");
+        SummonerDto summonerDto =  recordService.searchBySummonerName(summonerName);
+        ArrayList<String> matchesList = new ArrayList<>(recordService.searchMatchesByMatchId(summonerDto.getPuuid()));
+        List<LeagueDto> leagueList = recordService.searchLeagueBySummonerName(summonerDto.getId());
+
+        System.out.println(summonerDto);
+        System.out.println(leagueList);
+        System.out.println(matchesList);
+
+
+        return ResponseEntity.ok()
+                .body(new CMRespDto<>(HttpStatus.OK.value(), "Successfully Search", leagueList));
+    }
+
+
+
+}

--- a/goodgame.gg/src/main/java/fourjo/idle/goodgame/gg/web/dto/Record/LeagueDto.java
+++ b/goodgame.gg/src/main/java/fourjo/idle/goodgame/gg/web/dto/Record/LeagueDto.java
@@ -1,0 +1,25 @@
+package fourjo.idle.goodgame.gg.web.dto.Record;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class LeagueDto {
+    private String leagueId;
+    private String summonerId;
+    private String summonerName;
+    private String queueType;
+    private String tier;
+    private String rank;
+    private int leaguePoints;
+    private int wins;
+    private int losses;
+
+    private boolean hotStreak;
+    private boolean veteran;
+    private boolean freshBlood;
+    private boolean inactive;
+
+    private MiniSeriesDto miniSeriesDto;
+}

--- a/goodgame.gg/src/main/java/fourjo/idle/goodgame/gg/web/dto/Record/MiniSeriesDto.java
+++ b/goodgame.gg/src/main/java/fourjo/idle/goodgame/gg/web/dto/Record/MiniSeriesDto.java
@@ -1,0 +1,11 @@
+package fourjo.idle.goodgame.gg.web.dto.Record;
+
+import lombok.Data;
+
+@Data
+public class MiniSeriesDto {
+    private  int losses;
+    private int progress;
+    private int target;
+    private int wins;
+}

--- a/goodgame.gg/src/main/java/fourjo/idle/goodgame/gg/web/dto/Record/SummonerDto.java
+++ b/goodgame.gg/src/main/java/fourjo/idle/goodgame/gg/web/dto/Record/SummonerDto.java
@@ -1,0 +1,14 @@
+package fourjo.idle.goodgame.gg.web.dto.Record;
+
+import lombok.Data;
+
+@Data
+public class SummonerDto {
+    private String accountId;
+    private int profileIconId;
+    private long revisionDate;
+    private String name;
+    private String id;
+    private String puuid;
+    private long summonerLevel;
+}

--- a/goodgame.gg/src/main/java/fourjo/idle/goodgame/gg/web/service/RecordService.java
+++ b/goodgame.gg/src/main/java/fourjo/idle/goodgame/gg/web/service/RecordService.java
@@ -1,0 +1,104 @@
+package fourjo.idle.goodgame.gg.web.service;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import fourjo.idle.goodgame.gg.exception.CustomRiotResponseCodeException;
+import fourjo.idle.goodgame.gg.web.dto.Record.LeagueDto;
+import fourjo.idle.goodgame.gg.web.dto.Record.SummonerDto;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.util.*;
+
+@Service
+public class RecordService {
+
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    private final String mykey = "RGAPI-bd90af85-25ea-4424-913a-62bbbcf9a4e8";
+    private final String serverUrl = "https://kr.api.riotgames.com";
+    private final String severUrlAsia = "https://asia.api.riotgames.com/";
+
+    // 소한사 이름으로 검색
+    public SummonerDto searchBySummonerName(String summonerName){
+        SummonerDto summonerDto = new SummonerDto();
+        try {
+            HttpClient c = HttpClientBuilder.create().build();
+            HttpGet request = new HttpGet(serverUrl + "/lol/summoner/v4/summoners/by-name/" + summonerName + "?api_key=" + mykey);
+            HttpResponse response = c.execute(request);
+
+            riotResponseCodeError(response);
+
+            HttpEntity entity = response.getEntity();
+            summonerDto = objectMapper.readValue(entity.getContent(), SummonerDto.class);
+
+        } catch (IOException e){
+            e.printStackTrace();
+            return null;
+        }
+
+        return summonerDto;
+    }
+
+    // puuid로 게임정보 조회
+    public List<String> searchMatchesByMatchId (String puuid){
+        ArrayList<String> list = new ArrayList<>();
+
+        try {
+            HttpClient c = HttpClientBuilder.create().build();
+            HttpGet request = new HttpGet(severUrlAsia + "/lol/match/v5/matches/by-puuid/"+puuid+"/ids" + "?api_key=" + mykey);
+            HttpResponse response = c.execute(request);
+
+            riotResponseCodeError(response);
+
+            HttpEntity entity = response.getEntity();
+
+            List<String> matchesList = objectMapper.readValue(entity.getContent(), new TypeReference<>() {});
+
+            return matchesList;
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        return list;
+    }
+
+    // 리그정보 조회 - 랭크별, 티어별, 등급별, 소환사 정보 반환
+    public List<LeagueDto> searchLeagueBySummonerName(String enCodeSummonerName){
+        List<LeagueDto> leagueList = new ArrayList<LeagueDto>();
+        try {
+            HttpClient c = HttpClientBuilder.create().build();
+            HttpGet request = new HttpGet(serverUrl + "/lol/league/v4/entries/by-summoner/" + enCodeSummonerName + "?api_key=" + mykey);
+            HttpResponse response = c.execute(request);
+
+            riotResponseCodeError(response);
+
+            HttpEntity entity = response.getEntity();
+            leagueList = objectMapper.readValue(entity.getContent(), new TypeReference<>() {});
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        return leagueList;
+    }
+
+    /* CHAMPION-MASTERY-V4 - 유저, 챔피언 숙련도 조회Permalink
+    소환사의 챔피언 숙련도 정보 반환
+    /lol/champion-mastery/v4/champion-masteries/by-summoner/{encryptedSummonerId}
+    */
+
+    // 에러 메서드
+    public void riotResponseCodeError(HttpResponse response){
+        int code = response.getStatusLine().getStatusCode();
+        if(code != 200){
+            Map<String, Integer> errorMap = new HashMap<>();
+            errorMap.put("Riot Response Code", code);
+
+            throw new CustomRiotResponseCodeException(errorMap);
+        }
+    }
+
+}


### PR DESCRIPTION
pom.xml : 불필요한 dependency 삭제
- swagger-ui 연결하려다가 남은 잔재

exception : 예외 클래스 추가
- CustomRiotResponseCodeException 클래스 추가, Map<String, Integer>로 설정해 코드 반환

web.advice : 동일한 방식으로 에러 메서드 추가

dto : Summoner, League, MiniSeries 추가

service : 소환사로 검색, 게임정보 조회, 리그정보 조회, 에러 메서드 추가
- searchBySummonerName : 소환사로 입력받아서 summonerDto로 return
- searchMatchesByMatchId : puuid로 게임정보 리스트 받아서 matchesList로 리턴
- searchLeagueBySummonerName : encod된 소환사 이름을 받아 leagueList 반환
- riotResponseCodeError : 에러 메시지 출력

api : 소환사 이름 검색하면 나오는 api 생성
- SearchRecordAll : service의 searchBySummonerName, searchMatchesByMatchId, searchLeagueBySummonerName 를 받아 실행