### PR TITLE
변경사항 : 어드민 페이지 관련

### DIFF
--- a/goodgame.gg/pom.xml
+++ b/goodgame.gg/pom.xml
@@ -62,6 +62,14 @@
 
 
 		<dependency>
+			<groupId>org.apache.httpcomponents</groupId>
+			<artifactId>httpclient</artifactId>
+			<version>4.5</version>
+		</dependency>
+
+
+
+		<dependency>
 			<groupId>io.springfox</groupId>
 			<artifactId>springfox-swagger2</artifactId>
 			<version>3.0.0</version>

--- a/goodgame.gg/src/main/java/fourjo/idle/goodgame/gg/repository/AdminRepository.java
+++ b/goodgame.gg/src/main/java/fourjo/idle/goodgame/gg/repository/AdminRepository.java
@@ -1,7 +1,7 @@
 package fourjo.idle.goodgame.gg.repository;
 
-import fourjo.idle.goodgame.gg.web.dto.AdminBoardDTO;
-import fourjo.idle.goodgame.gg.web.dto.AdminBoardSearchDTO;
+import fourjo.idle.goodgame.gg.web.dto.Admin.AdminBoardDTO;
+import fourjo.idle.goodgame.gg.web.dto.Admin.AdminBoardSearchDTO;
 import org.apache.ibatis.annotations.Mapper;
 
 import java.util.List;
@@ -9,17 +9,12 @@ import java.util.List;
 @Mapper
 public interface AdminRepository {
 
-    public int admin_board_insert(AdminBoardDTO dto);
+    public int boardInsertByUserIndex(AdminBoardDTO adminBoardDTO);
 
-    public int admin_board_update(AdminBoardDTO dto);
+    public int boardUpdateByBoardIndex(AdminBoardDTO adminBoardDTO);
 
-    public int admin_board_delete(int board_index);
-
-
+    public int boardDeleteByBoardIndex(int boardIndex);
 
 
-
-    public List<AdminBoardDTO> admin_board_selectAll();
-
-    public List<AdminBoardDTO> AdminBoardSearch(AdminBoardSearchDTO adminBoardSearchDTO);
+    public List<AdminBoardDTO> boardSearchAllBySubjectAndContentAndNickAndId(AdminBoardSearchDTO adminBoardSearchDTO);
 }

--- a/goodgame.gg/src/main/java/fourjo/idle/goodgame/gg/repository/RankingRepository.java
+++ b/goodgame.gg/src/main/java/fourjo/idle/goodgame/gg/repository/RankingRepository.java
@@ -1,0 +1,18 @@
+package fourjo.idle.goodgame.gg.repository;
+
+import fourjo.idle.goodgame.gg.web.dto.Admin.AdminBoardDTO;
+import fourjo.idle.goodgame.gg.web.dto.Ranking.LeagueEntryDto;
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface RankingRepository {
+
+    public int rankingInsert(LeagueEntryDto LeagueDto);
+
+    public int rankingUpdate(AdminBoardDTO adminBoardDTO);
+
+    public int rankingDelete(int boardIndex);
+
+
+
+}

--- a/goodgame.gg/src/main/java/fourjo/idle/goodgame/gg/web/api/AdminApi.java
+++ b/goodgame.gg/src/main/java/fourjo/idle/goodgame/gg/web/api/AdminApi.java
@@ -1,9 +1,10 @@
 package fourjo.idle.goodgame.gg.web.api;
 
-import fourjo.idle.goodgame.gg.web.dto.AdminBoardDTO;
-import fourjo.idle.goodgame.gg.web.dto.AdminBoardSearchDTO;
+import fourjo.idle.goodgame.gg.web.dto.Admin.AdminBoardDTO;
+import fourjo.idle.goodgame.gg.web.dto.Admin.AdminBoardSearchDTO;
 import fourjo.idle.goodgame.gg.web.dto.CMRespDto;
 import fourjo.idle.goodgame.gg.web.service.AdminService;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -17,49 +18,43 @@ import org.springframework.web.bind.annotation.*;
 @Slf4j
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/admin_board")
-@Tag(name ="admin_board_Api", description = "admin board Api 입니다.")
+@RequestMapping("/api/admin")
+@Tag(name ="Admin Board Api", description = "Admin Board Api 입니다.")
 public class AdminApi {
 
     @Autowired
     private AdminService adminService;
 
-    @PostMapping("/admin_board_insert")
-    public ResponseEntity<CMRespDto<?>> admin_board_insert (@RequestBody AdminBoardDTO dto, BindingResult bindingResult){
-        log.info("DTO:{}",dto);
-        adminService.admin_board_insert(dto);
+    @Operation( summary = "게시글 삽입 Api", description = "게시글을 userIndex를 기준으로 작성합니다.")
+    @PostMapping("/board/insert")
+    public ResponseEntity<CMRespDto<?>> boardInsertByUserIndex (@RequestBody AdminBoardDTO adminBoardDTO, BindingResult bindingResult){
+        adminService.boardInsertByUserIndex(adminBoardDTO);
         return ResponseEntity.ok()
                 .body(new CMRespDto<>(HttpStatus.OK.value(), "Successfully registered", true));
     }
 
-    @PostMapping("/admin_board_update")
-    public ResponseEntity<CMRespDto<?>> admin_board_update (@RequestBody AdminBoardDTO dto){
-        adminService.admin_board_update(dto);
-        log.info("DTO:{}",dto);
+    @Operation( summary = "게시글 수정 Api", description = "게시글을 boardIndex를 기준으로 수정합니다.")
+    @PatchMapping("/board/update")
+    public ResponseEntity<CMRespDto<?>> boardUpdateByBoardIndex (@RequestBody AdminBoardDTO adminBoardDTO){
+        adminService.boardUpdateByBoardIndex(adminBoardDTO);
         return ResponseEntity.ok()
                 .body(new CMRespDto<>(HttpStatus.OK.value(), "Successfully registered", true));
     }
 
-    @DeleteMapping("/admin_board_delete")
-    public ResponseEntity<CMRespDto<?>> admin_board_delete (int board_index){
-        log.info("Board_index:{}",board_index);
-        adminService.admin_board_delete(board_index);
+//    @Operation( summary = "게시글 삭제 Api", description = "게시글을 boardIndex를 기준으로 삭제합니다.")
+    @DeleteMapping("/board/delete")
+    public ResponseEntity<CMRespDto<?>> boardDeleteByBoardIndex (int boardIndex){
+        adminService.boardDeleteByBoardIndex(boardIndex);
         return ResponseEntity.ok()
                 .body(new CMRespDto<>(HttpStatus.OK.value(), "Successfully registered", true));
     }
 
-    @GetMapping ("/admin_board_select")
-    public ResponseEntity<CMRespDto<?>> admin_board_selectAll (){
-        log.info("admin_board_selectAll");
-        return ResponseEntity.ok()
-                .body(new CMRespDto<>(HttpStatus.OK.value(), "Successfully registered", adminService.admin_board_selectAll()));
-    }
 
-    @GetMapping ("/AdminBoardSearch")
-    public ResponseEntity<CMRespDto<?>> AdminBoardSearch (AdminBoardSearchDTO adminBoardSearchDTO){
-        log.info("AdminBoardSearch");
+    @Operation( summary = "게시글 검색 Api", description = "게시글을 제목+내용,제목,내용,닉네임,아이디 로 검색 합니다.")
+    @GetMapping ("/board/search")
+    public ResponseEntity<CMRespDto<?>> boardSearchAllBySubjectAndContentAndNickAndId (AdminBoardSearchDTO adminBoardSearchDTO){
         return ResponseEntity.ok()
-                .body(new CMRespDto<>(HttpStatus.OK.value(), "Successfully registered", adminService.AdminBoardSearch(adminBoardSearchDTO)));
+                .body(new CMRespDto<>(HttpStatus.OK.value(), "Successfully registered", adminService.boardSearchAllBySubjectAndContentAndNickAndId(adminBoardSearchDTO)));
     }
 
 }

--- a/goodgame.gg/src/main/java/fourjo/idle/goodgame/gg/web/api/RankingApi.java
+++ b/goodgame.gg/src/main/java/fourjo/idle/goodgame/gg/web/api/RankingApi.java
@@ -1,0 +1,140 @@
+package fourjo.idle.goodgame.gg.web.api;
+
+import fourjo.idle.goodgame.gg.web.dto.CMRespDto;
+import fourjo.idle.goodgame.gg.web.dto.Ranking.LeagueEntryDto;
+import fourjo.idle.goodgame.gg.web.dto.Ranking.LeagueListDto;
+import fourjo.idle.goodgame.gg.web.dto.Ranking.SummonerDto;
+import fourjo.idle.goodgame.gg.web.service.RankingService;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.ArrayList;
+import java.util.List;
+
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/riot")
+@Tag(name ="Riot Api", description = "Riot Api 입니다.")
+public class RankingApi {
+
+    @Autowired
+    private RankingService rankingService;
+
+    @GetMapping("/search/summonerV4")
+    public ResponseEntity<CMRespDto<?>> searchSummonerInfoBySummonerName (String summonerName){
+
+        summonerName = summonerName.replaceAll(" ", "%20");
+        SummonerDto summonerDto = rankingService.searchSummonerInfoBySummonerName(summonerName);
+
+        return ResponseEntity.ok()
+                .body(new CMRespDto<>(HttpStatus.OK.value(), "Successfully registered", summonerDto));
+    }
+
+    @GetMapping("/search/leagueV4")
+    public ResponseEntity<CMRespDto<?>> searchLeagueById (String encryptedSummonerId){
+
+        List<LeagueEntryDto> leagueInfo = rankingService.searchLeagueById(encryptedSummonerId);
+
+        return ResponseEntity.ok()
+                .body(new CMRespDto<>(HttpStatus.OK.value(), "Successfully registered", leagueInfo));
+    }
+
+
+    @GetMapping("/search/summonerProfile")
+    public ResponseEntity<CMRespDto<?>> searchSummonerProfileBySummonerName (String summonerName){
+        summonerName = summonerName.replaceAll(" ", "%20");
+        SummonerDto summonerDto = rankingService.searchSummonerInfoBySummonerName(summonerName);
+        List<LeagueEntryDto> leagueInfo = rankingService.searchLeagueById(summonerDto.getId());
+        List<Object> result = new ArrayList<>();
+        result.add(summonerDto);
+        result.add(leagueInfo);
+
+
+
+        return ResponseEntity.ok()
+                .body(new CMRespDto<>(HttpStatus.OK.value(), "Successfully registered", result));
+    }
+
+
+    @GetMapping("/ranking/challengerLeagues")
+    public ResponseEntity<CMRespDto<?>> listChallengerLeaguesByQueue (String queue){
+
+        LeagueListDto challengerRanking = rankingService.challengerLeaguesByQueue(queue);
+
+        return ResponseEntity.ok()
+                .body(new CMRespDto<>(HttpStatus.OK.value(), "Successfully registered", challengerRanking));
+    }
+
+    @GetMapping("/ranking/grandmasterLeagues")
+    public ResponseEntity<CMRespDto<?>> listGrandmasterLeaguesByQueue (String queue){
+
+        LeagueListDto grandmasterRanking = rankingService.grandmasterLeaguesByQueue(queue);
+
+        return ResponseEntity.ok()
+                .body(new CMRespDto<>(HttpStatus.OK.value(), "Successfully registered", grandmasterRanking));
+    }
+
+    @GetMapping("/ranking/masterLeagues")
+    public ResponseEntity<CMRespDto<?>> listMasterLeaguesByQueue (String queue){
+
+        LeagueListDto masterRanking = rankingService.masterLeaguesByQueue(queue);
+
+        return ResponseEntity.ok()
+                .body(new CMRespDto<>(HttpStatus.OK.value(), "Successfully registered", masterRanking));
+    }
+
+    @GetMapping("/ranking/entriesLeagues")
+    public ResponseEntity<CMRespDto<?>> listEntriesLeagues (String tier, String division,String queue, int page){
+
+        List<LeagueEntryDto> entriesRanking = rankingService.entriesLeagues(tier,division,queue,page);
+
+        return ResponseEntity.ok()
+                .body(new CMRespDto<>(HttpStatus.OK.value(), "Successfully registered", entriesRanking));
+    }
+
+
+    @PostMapping("/ranking/DBInsert")
+    public ResponseEntity<CMRespDto<?>> rankingInsert (String tier, String queue) {
+        String division = "";
+        for (int j = 1; j<=4; j++) {
+            if(j==1){
+                division = "I";
+            }else if (j==2){
+                division = "II";
+            } else if (j==3) {
+                division = "III";
+            }else{
+                division= "IV";
+            }
+            int page = 0;
+            while (true) {
+
+                page++;
+                List<LeagueEntryDto> entriesRanking = rankingService.entriesLeagues(tier, division, queue, page);
+                System.out.println(entriesRanking);
+                if (page==2) {
+                    break;
+                }
+
+                for (int i = 0; i < entriesRanking.size(); i++) {
+                    rankingService.rankingInsert(entriesRanking.get(i));
+                }
+
+            }
+        }
+
+            return ResponseEntity.ok()
+                    .body(new CMRespDto<>(HttpStatus.OK.value(), "Successfully registered", true));
+        }
+
+
+
+}

--- a/goodgame.gg/src/main/java/fourjo/idle/goodgame/gg/web/controller/AdminController.java
+++ b/goodgame.gg/src/main/java/fourjo/idle/goodgame/gg/web/controller/AdminController.java
@@ -7,6 +7,6 @@ import org.springframework.web.bind.annotation.GetMapping;
 @Slf4j
 @Controller
 public class AdminController {
-    @GetMapping("/admin_home")
-    public String admin_home () {return "admin/admin_home";}
+    @GetMapping("/adminHome")
+    public String adminHome () {return "admin/admin_home";}
 }

--- a/goodgame.gg/src/main/java/fourjo/idle/goodgame/gg/web/dto/Admin/AdminBoardDTO.java
+++ b/goodgame.gg/src/main/java/fourjo/idle/goodgame/gg/web/dto/Admin/AdminBoardDTO.java
@@ -1,0 +1,19 @@
+package fourjo.idle.goodgame.gg.web.dto.Admin;
+
+import lombok.Data;
+
+import java.util.Date;
+
+@Data
+public class AdminBoardDTO {
+    private int boardIndex;
+    private String boardSubject;
+    private int userIndex;
+    private String boardContent;
+    private Date boardRegDate;
+    private int boardVisit;
+    private String boardUploadName;
+    private Long boardUploadSize;
+    private String boardUploadLocation;
+
+}

--- a/goodgame.gg/src/main/java/fourjo/idle/goodgame/gg/web/dto/Admin/AdminBoardSearchDTO.java
+++ b/goodgame.gg/src/main/java/fourjo/idle/goodgame/gg/web/dto/Admin/AdminBoardSearchDTO.java
@@ -1,4 +1,4 @@
-package fourjo.idle.goodgame.gg.web.dto;
+package fourjo.idle.goodgame.gg.web.dto.Admin;
 
 import lombok.Data;
 

--- a/goodgame.gg/src/main/java/fourjo/idle/goodgame/gg/web/dto/Ranking/LeagueEntryDto.java
+++ b/goodgame.gg/src/main/java/fourjo/idle/goodgame/gg/web/dto/Ranking/LeagueEntryDto.java
@@ -1,0 +1,23 @@
+package fourjo.idle.goodgame.gg.web.dto.Ranking;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Data;
+
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class LeagueEntryDto implements Comparable<LeagueEntryDto>{
+//    private String leagueId;
+//    private String summonerId;
+    private String summonerName;
+    private String queueType;
+    private String tier;
+    private String rank;
+    private int leaguePoints;
+    private int wins;
+    private int losses;
+
+    @Override
+    public int compareTo(LeagueEntryDto o) {
+        return (o.leaguePoints - leaguePoints);
+    }
+}

--- a/goodgame.gg/src/main/java/fourjo/idle/goodgame/gg/web/dto/Ranking/LeagueItemDto.java
+++ b/goodgame.gg/src/main/java/fourjo/idle/goodgame/gg/web/dto/Ranking/LeagueItemDto.java
@@ -1,0 +1,21 @@
+package fourjo.idle.goodgame.gg.web.dto.Ranking;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Data;
+
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class LeagueItemDto implements Comparable<LeagueItemDto> {
+    private String summonerId;
+    private String summonerName;
+    private String rank;
+    private int leaguePoints;
+    private int wins;
+    private int losses;
+
+
+    @Override
+    public int compareTo(LeagueItemDto o) {
+        return (o.leaguePoints - leaguePoints);
+    }
+}

--- a/goodgame.gg/src/main/java/fourjo/idle/goodgame/gg/web/dto/Ranking/LeagueListDto.java
+++ b/goodgame.gg/src/main/java/fourjo/idle/goodgame/gg/web/dto/Ranking/LeagueListDto.java
@@ -1,0 +1,16 @@
+package fourjo.idle.goodgame.gg.web.dto.Ranking;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class LeagueListDto {
+    private String leagueId;
+    private String tier;
+    private String name;
+    private String queue;
+    private List<LeagueItemDto> entries;
+}

--- a/goodgame.gg/src/main/java/fourjo/idle/goodgame/gg/web/dto/Ranking/SummonerDto.java
+++ b/goodgame.gg/src/main/java/fourjo/idle/goodgame/gg/web/dto/Ranking/SummonerDto.java
@@ -1,0 +1,18 @@
+package fourjo.idle.goodgame.gg.web.dto.Ranking;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Data;
+
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class SummonerDto {
+//    private String accountId;
+//    private long revisionDate;
+    private String id;
+    private String puuid;
+    private long summonerLevel;
+    private int profileIconId;
+    private String name;
+
+
+}

--- a/goodgame.gg/src/main/java/fourjo/idle/goodgame/gg/web/service/AdminService.java
+++ b/goodgame.gg/src/main/java/fourjo/idle/goodgame/gg/web/service/AdminService.java
@@ -1,8 +1,8 @@
 package fourjo.idle.goodgame.gg.web.service;
 
 import fourjo.idle.goodgame.gg.repository.AdminRepository;
-import fourjo.idle.goodgame.gg.web.dto.AdminBoardDTO;
-import fourjo.idle.goodgame.gg.web.dto.AdminBoardSearchDTO;
+import fourjo.idle.goodgame.gg.web.dto.Admin.AdminBoardDTO;
+import fourjo.idle.goodgame.gg.web.dto.Admin.AdminBoardSearchDTO;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -14,23 +14,19 @@ public class AdminService {
     @Autowired
     private AdminRepository adminRepository;
 
-    public int admin_board_insert(AdminBoardDTO dto) {
-        return adminRepository.admin_board_insert(dto);
+    public int boardInsertByUserIndex(AdminBoardDTO adminBoardDTO) {
+        return adminRepository.boardInsertByUserIndex(adminBoardDTO);
     }
 
-    public int admin_board_update(AdminBoardDTO dto) {
-        return adminRepository.admin_board_update(dto);
+    public int boardUpdateByBoardIndex(AdminBoardDTO adminBoardDTO) {
+        return adminRepository.boardUpdateByBoardIndex(adminBoardDTO);
     }
 
-    public int admin_board_delete(int board_index) {
-        return adminRepository.admin_board_delete(board_index);
+    public int boardDeleteByBoardIndex(int boardIndex) {
+        return adminRepository.boardDeleteByBoardIndex(boardIndex);
     }
 
-    public List<AdminBoardDTO> admin_board_selectAll() {
-        return adminRepository.admin_board_selectAll();
-    }
-
-    public List<AdminBoardDTO> AdminBoardSearch(AdminBoardSearchDTO adminBoardSearchDTO) {
-        return adminRepository.AdminBoardSearch(adminBoardSearchDTO);
+    public List<AdminBoardDTO> boardSearchAllBySubjectAndContentAndNickAndId(AdminBoardSearchDTO adminBoardSearchDTO) {
+        return adminRepository.boardSearchAllBySubjectAndContentAndNickAndId(adminBoardSearchDTO);
     }
 }

--- a/goodgame.gg/src/main/java/fourjo/idle/goodgame/gg/web/service/RankingService.java
+++ b/goodgame.gg/src/main/java/fourjo/idle/goodgame/gg/web/service/RankingService.java
@@ -1,0 +1,191 @@
+package fourjo.idle.goodgame.gg.web.service;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import fourjo.idle.goodgame.gg.repository.RankingRepository;
+import fourjo.idle.goodgame.gg.web.dto.Ranking.LeagueEntryDto;
+import fourjo.idle.goodgame.gg.web.dto.Ranking.LeagueListDto;
+import fourjo.idle.goodgame.gg.web.dto.Ranking.SummonerDto;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+@Service
+public class RankingService {
+
+    @Autowired
+    RankingRepository rankingRepository;
+
+    private ObjectMapper objectMapper = new ObjectMapper();
+    private final HttpClient client = HttpClientBuilder.create().build();
+
+    private final String ApiKey = "RGAPI-0fdd97d4-5567-4eba-89fc-404501a3a849";
+    private final String serverUri = "https://kr.api.riotgames.com";
+    private final String serverUriAsia = "https://asia.api.riotgames.com";
+
+    private final String solo = "/RANKED_SOLO_5x5";
+    private final String flex = "/RANKED_FLEX_SR";
+
+
+
+    public SummonerDto searchSummonerInfoBySummonerName(String summonerName) {
+        SummonerDto summonerDto = new SummonerDto();
+
+        try {
+            HttpGet request = new HttpGet(serverUri + "/lol/summoner/v4/summoners/by-name/" + summonerName + "?api_key=" + ApiKey);
+            HttpResponse response = client.execute(request);
+
+//            riotResponseCodeError(response);
+
+            HttpEntity entity = response.getEntity();
+            summonerDto = objectMapper.readValue(entity.getContent(), SummonerDto.class);
+
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        return summonerDto;
+    }
+
+    public List<LeagueEntryDto> searchLeagueById(String encryptedSummonerId) {
+        List<LeagueEntryDto> leagueInfo = new ArrayList<>();
+
+        try {
+            HttpGet request = new HttpGet(serverUri + "/lol/league/v4/entries/by-summoner/" + encryptedSummonerId + "?api_key=" + ApiKey);
+            HttpResponse response = client.execute(request);
+
+//            riotResponseCodeError(response);
+
+            HttpEntity entity = response.getEntity();
+            leagueInfo = objectMapper.readValue(entity.getContent(), new TypeReference<>() {
+            });
+
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        return leagueInfo;
+    }
+
+    public LeagueListDto challengerLeaguesByQueue(String queue) {
+        LeagueListDto challengerRanking = new LeagueListDto();
+
+        if (queue.equals("solo")) {
+            queue = solo;
+        } else if (queue.equals("flex")) {
+            queue = flex;
+        }
+
+        try {
+            HttpGet request = new HttpGet(serverUri + "/lol/league/v4/challengerleagues/by-queue" + queue + "?api_key=" + ApiKey);
+            HttpResponse response = client.execute(request);
+
+//            riotResponseCodeError(response);
+
+            HttpEntity entity = response.getEntity();
+            challengerRanking = objectMapper.readValue(entity.getContent(), new TypeReference<>() {});
+            Collections.sort(challengerRanking.getEntries());
+//            challengerRanking.getEntries().sort(Comparator.comparingInt(LeagueItemDto::getLeaguePoints).reversed());
+
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        return challengerRanking;
+    }
+
+
+
+    public LeagueListDto grandmasterLeaguesByQueue(String queue){
+            LeagueListDto grandmasterRanking = new LeagueListDto();
+
+            if (queue.equals("solo")) {
+                queue = solo;
+            } else if (queue.equals("flex")) {
+                queue = flex;
+            }
+
+            try {
+                HttpGet request = new HttpGet(serverUri + "/lol/league/v4/grandmasterleagues/by-queue" + queue + "?api_key=" + ApiKey);
+                HttpResponse response = client.execute(request);
+
+//            riotResponseCodeError(response);
+
+                HttpEntity entity = response.getEntity();
+                grandmasterRanking = objectMapper.readValue(entity.getContent(), new TypeReference<>() {});
+                Collections.sort(grandmasterRanking.getEntries());
+//                grandmasterRanking.getEntries().sort(Comparator.comparingInt(LeagueItemDto::getLeaguePoints).reversed());
+
+            } catch (IOException e){
+                e.printStackTrace();
+            }
+            return grandmasterRanking;
+    }
+
+    public LeagueListDto masterLeaguesByQueue(String queue){
+        LeagueListDto masterRanking = new LeagueListDto();
+
+        if (queue.equals("solo")) {
+            queue = solo;
+        } else if (queue.equals("flex")) {
+            queue = flex;
+        }
+
+        try {
+            HttpGet request = new HttpGet(serverUri + "/lol/league/v4/masterleagues/by-queue" + queue + "?api_key=" + ApiKey);
+            HttpResponse response = client.execute(request);
+
+//            riotResponseCodeError(response);
+
+            HttpEntity entity = response.getEntity();
+            masterRanking = objectMapper.readValue(entity.getContent(), new TypeReference<>() {});
+
+            System.out.println(masterRanking.getEntries().size());
+            Collections.sort(masterRanking.getEntries());
+//            masterRanking.getEntries().sort(Comparator.comparingInt(LeagueItemDto::getLeaguePoints).reversed());
+
+        } catch (IOException e){
+            e.printStackTrace();
+        }
+        return masterRanking;
+    }
+
+
+
+
+    public List<LeagueEntryDto> entriesLeagues(String tier, String division, String queue, int page){
+        List<LeagueEntryDto> entriesRanking = new ArrayList<>();
+
+        if (queue.equals("solo")) {
+            queue = solo;
+        } else if (queue.equals("flex")) {
+            queue = flex;
+        }
+
+        try {
+            HttpGet request = new HttpGet(serverUri + "/lol/league/v4/entries" + queue +"/"+ tier +"/"+ division + "?page=" + page +"&api_key=" + ApiKey);
+            HttpResponse response = client.execute(request);
+
+//            riotResponseCodeError(response);
+
+            HttpEntity entity = response.getEntity();
+            entriesRanking = objectMapper.readValue(entity.getContent(), new TypeReference<>() {});
+//            Collections.sort(entriesRanking);
+//            entriesRanking.getEntries().sort(Comparator.comparingInt(LeagueItemDto::getLeaguePoints).reversed());
+
+        } catch (IOException e){
+            e.printStackTrace();
+        }
+        return entriesRanking;
+    }
+
+    public int rankingInsert(LeagueEntryDto LeagueDto) {
+        return rankingRepository.rankingInsert(LeagueDto);
+    }
+}

--- a/goodgame.gg/src/main/resources/mappers/admin.xml
+++ b/goodgame.gg/src/main/resources/mappers/admin.xml
@@ -4,46 +4,45 @@
         "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="fourjo.idle.goodgame.gg.repository.AdminRepository">
 
-    <insert id="admin_board_insert" parameterType="fourjo.idle.goodgame.gg.web.dto.AdminBoardDTO">
+    <insert id="boardInsertByUserIndex" parameterType="fourjo.idle.goodgame.gg.web.dto.Admin.AdminBoardDTO">
         insert into board_mst
-        values( 0, #{board_subject},#{user_index}, #{board_content}, now(), #{board_visit},#{board_good},#{board_bad}, #{board_upload_name},#{board_upload_size},#{board_upload_trans} )
+        values( 0, #{boardSubject},#{userIndex}, #{boardContent}, now(), #{boardVisit},#{boardUploadName},#{boardUploadSize},#{boardUploadLocation} )
     </insert>
 
-    <update id="admin_board_update" parameterType="fourjo.idle.goodgame.gg.web.dto.AdminBoardDTO">
-        update board_mst set board_subject = #{board_subject}, board_content = #{board_content}
-        where board_index = #{board_index}
+    <update id="boardUpdateByBoardIndex" parameterType="fourjo.idle.goodgame.gg.web.dto.Admin.AdminBoardDTO">
+        update board_mst set boardSubject = #{boardSubject}, boardContent = #{boardContent}
+        where boardIndex = #{boardIndex}
 
     </update>
 
-    <delete id="admin_board_delete" parameterType="integer">
-        delete from board_mst where board_index = #{board_index}
+    <delete id="boardDeleteByBoardIndex" parameterType="integer">
+        delete from board_mst where boardIndex = #{boardIndex}
     </delete>
 
-    <select id="admin_board_selectAll" resultType="fourjo.idle.goodgame.gg.web.dto.AdminBoardDTO">
-        select * from board_mst
-    </select>
-
-    <select id="AdminBoardSearch" parameterType="fourjo.idle.goodgame.gg.web.dto.AdminBoardSearchDTO" resultType="fourjo.idle.goodgame.gg.web.dto.AdminBoardDTO">
-            select * from board_mst
-            <if test='searchKey == "sc" and searchValue != null and searchValue !=""'>
+    <select id="boardSearchAllBySubjectAndContentAndNickAndId" parameterType="fourjo.idle.goodgame.gg.web.dto.Admin.AdminBoardSearchDTO" resultType="fourjo.idle.goodgame.gg.web.dto.Admin.AdminBoardDTO">
+            select * from board_mst bm
+            inner join user_mst um
+            on bm.userIndex = um.userIndex
+            <if test='searchKey == "subjectAndContent" and searchValue != null and searchValue !=""'>
                 where (
-                board_subject like CONCAT('%', #{searchValue}, '%')
-                or board_content like CONCAT('%', #{searchValue}, '%')
+                boardSubject like CONCAT('%', #{searchValue}, '%')
+                or boardContent like CONCAT('%', #{searchValue}, '%')
                 )
             </if>
             <if test='searchKey == "subject" and searchValue != null and searchValue !=""'>
-                where board_subject like CONCAT('%', #{searchValue}, '%')
+                where boardSubject like CONCAT('%', #{searchValue}, '%')
             </if>
             <if test='searchKey == "content" and searchValue != null and searchValue !=""'>
-                where board_content like CONCAT('%', #{searchValue}, '%')
+                where boardContent like CONCAT('%', #{searchValue}, '%')
             </if>
              <if test='searchKey == "nick" and searchValue != null and searchValue !=""'>
-                 bm join user_mst um
-                 on bm.user_index = um.user_index
-                 where um.user_nick like CONCAT('%', #{searchValue}, '%')
+                 where um.userNick like CONCAT('%', #{searchValue}, '%')
+            </if>
+             <if test='searchKey == "id" and searchValue != null and searchValue !=""'>
+                where um.userId like CONCAT('%', #{searchValue}, '%')
             </if>
         order by
-        board_index desc
+        boardIndex desc
         <if test='limit == "Y"'>
             limit #{index}, #{count}
         </if>

--- a/goodgame.gg/src/main/resources/mappers/ranking.xml
+++ b/goodgame.gg/src/main/resources/mappers/ranking.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="fourjo.idle.goodgame.gg.repository.RankingRepository">
+
+    <insert id="rankingInsert" parameterType="fourjo.idle.goodgame.gg.web.dto.Ranking.LeagueEntryDto">
+        insert into ranking_mst
+        values( 0, #{summonerName},#{queueType}, #{tier}, #{rank},#{leaguePoints},#{wins},#{losses} )
+    </insert>
+
+
+
+
+
+</mapper>


### PR DESCRIPTION
AdminApi
AdminService
AdminController
AdminRepository
admin.xml
- 메소드명,매개변수 명 카멜표기법으로 통일및 정리 pom.xml
-HttpClient api 파싱용 디펜던시 추가

신규사항: 랭킹 기능 작업중...
RankingApi 클래스 생성
- /api/riot/ranking/challengerLeagues 챌린저 목록 호출 및 LP 내림차 정렬
- /api/riot/ranking/grandmasterLeagues 그랜드마스터 목록 호출 및 LP 내림차 정렬
- /api/riot/ranking/masterLeagues 마스터 목록 호출 및 LP 내림차 정렬
- /api/riot/ranking/entriesLeagues 다이아몬드 이하 티어 호출 및 LP 내림차 정렬

- /api/riot/search/SummonerV4 소환사 정보 호출
- /api/riot/search/LeagueV4 소환사 티어 정보 호출
- /api/riot/search/SummonerProfile LeagueV4+SummonerV4 동시호출

- /api/riot/ranking/DBInsert 다이아몬드 이하 티어 ranking_mst 테이블에 삽입

RankingService 클래스 생성
- 랭킹 관련 api 연동 및 파싱처리

RankingRepository 클래스 생성
- 다이아몬드 이하 티어 ranking_mst 테이블에 삽입을 위한 레포지토리

ranking.xml 맵퍼 생성
- 다이아몬드 이하 티어 ranking_mst 테이블에 삽입을 위한 맵퍼

LeagueListDTO 클래스 생성
- 챌린저,그랜드마스터,마스터 Api 맵핑용

- List<LeagueItemDto> 타입의 entries 객체를 위한 ㄴLeagueitemDTO 클래스 생성
    - Comparable 상속으로 leaguePoints 내림차순 정렬

LeagueEntryDTO 클래스 추가
- 다이아몬드 1 이하 Api 매핑용
- Comparable 상속으로 leaguePoints 내림차순 정렬